### PR TITLE
Update Engine Pages

### DIFF
--- a/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/Panel.xml
+++ b/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/Panel.xml
@@ -337,16 +337,16 @@
 		</Condition>
 	</Annunciation>
 	<!--Indicates that the standby alternator is generating electrical power-->
-	<!-- <Annunciation>
+	<Annunciation>
 	  <Type>Advisory</Type>
 	  <Text>STBY PWR ON</Text>
 		<Condition>
 			<Greater>
 				<Simvar name="ELECTRICAL GENALT BUS AMPS:2" unit="amp"/>
-				<Constant>2</Constant>
+				<Constant>40</Constant>
 			</Greater>
 		</Condition>
-	</Annunciation> -->
+	</Annunciation>
 	<!--Indicates electrical power is being supplied to the engine ignition system-->		
 	<Annunciation>
 	  <Type>Advisory</Type>
@@ -492,7 +492,7 @@
 								</Greater>
 							</Transition>
 						</State>
-						<State id="Normal" value="805">
+						<State id="Normal" value="850">
 							<Transition to="Start">
 								<Lower>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -531,6 +531,14 @@
 				<Begin>55</Begin>
 				<End>103.6</End>
 			</ColorZone>
+                     <ColorLine>
+				<Color>white</Color>
+				<Position>12</Position>
+			</ColorLine>
+			<ColorLine>
+				<Color>white</Color>
+				<Position>50</Position>
+			</ColorLine>
 			<ColorLine>
 				<Color>red</Color>
 				<Position>103.7</Position>
@@ -593,27 +601,27 @@
 			<Title>OIL</Title>
 			<Unit>PSI</Unit>
 			<Minimum>0</Minimum>
-			<Maximum>120</Maximum>
+			<Maximum>130</Maximum>
 			<Value>
 				<Simvar name="GENERAL ENG OIL PRESSURE:1" unit="psi"/>
 			</Value>
 			<ColorZone>
 				<Color>green</Color>
 				<Begin>85</Begin>
-				<End>120</End>
+				<End>105</End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
 				<Begin>40</Begin>
-				<End>85</End>
+				<End>84</End>
 			</ColorZone>
 			<ColorLine>
 				<Color>red</Color>
-				<Position>40</Position>
+				<Position>39</Position>
 			</ColorLine>
 			<ColorLine>
 				<Color>red</Color>
-				<Position>120</Position>
+				<Position>105</Position>
 			</ColorLine>
 			<BeginText></BeginText>
 			<EndText></EndText>
@@ -621,7 +629,7 @@
 				<Or>
 					<Greater>
 						<Simvar name="GENERAL ENG OIL PRESSURE:1" unit="psi"/>
-						<Constant>101.6</Constant>
+						<Constant>105</Constant>
 					</Greater>
 					<Lower>
 						<Simvar name="GENERAL ENG OIL PRESSURE:1" unit="psi"/>
@@ -661,11 +669,11 @@
 			</ColorZone>
 			<ColorLine>
 				<Color>red</Color>
-				<Position>-40</Position>
+				<Position>-41</Position>
 			</ColorLine>
 			<ColorLine>
 				<Color>red</Color>
-				<Position>104</Position>
+				<Position>105</Position>
 			</ColorLine>
 			<BeginText></BeginText>
 			<EndText></EndText>
@@ -677,7 +685,7 @@
 					</Greater>
 					<Lower>
 						<Simvar name="GENERAL ENG OIL TEMPERATURE:1" unit="celsius"/>
-						<Constant>-41</Constant>
+						<Constant>-40</Constant>
 					</Lower>
 				</Or>
 			</RedBlink>
@@ -725,8 +733,8 @@
 		</Gauge>
 		
 		<Text>
-			<Left>FFLOW PPH</Left>
-			<Right id="FuelFlow">
+			<Left fontsize="8">FFLOW PPH</Left>
+			<Right id="FuelFlow" fontsize="9">
 				<ToFixed precision="0">
 					<Simvar name="ENG FUEL FLOW PPH:1" unit="Pounds per hour"/>
 				</ToFixed>
@@ -734,18 +742,18 @@
 		</Text>
 		
 		<Text>
-			<Left>BAT AMPS</Left>
-			<Right id="Amperes">
+			<Left fontsize="8">BAT AMPS</Left>
+			<Right id="Amperes" fontsize="9">
 				<ToFixed precision="0">
-					<Simvar name="ELECTRICAL BATTERY LOAD:1" unit="Amperes"/>
+					<Simvar name="ELECTRICAL MAIN BUS AMPS:1" unit="Amperes"/>
 				</ToFixed>
 			</Right>
 		</Text>
 		
 		<Text>
-			<Left>BUS VOLTS</Left>
-			<Right id="Volts">
-				<ToFixed precision="0">
+			<Left fontsize="8">BUS VOLTS</Left>
+			<Right id="Volts" fontsize="9">
+				<ToFixed precision="1">
 					<Simvar name="ELECTRICAL MAIN BUS VOLTAGE:1" unit="Volts"/>
 				</ToFixed>
 			</Right>

--- a/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/Panel.xml
+++ b/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/Panel.xml
@@ -341,10 +341,28 @@
 	  <Type>Advisory</Type>
 	  <Text>STBY PWR ON</Text>
 		<Condition>
-			<Greater>
-				<Simvar name="ELECTRICAL GENALT BUS AMPS:2" unit="amp"/>
-				<Constant>40</Constant>
-			</Greater>
+                     <And>
+                            <Greater>
+                                   <Simvar name="ELECTRICAL GENALT BUS AMPS:2" unit="amp"/>
+                                   <Constant>2</Constant>
+                            </Greater>
+                            <And>
+                                   <Or>
+                                          <Greater>
+                                                 <Simvar name="ELECTRICAL BATTERY LOAD:1" unit="amps"/>
+                                                 <Constant>0</Constant>
+                                          </Greater>
+                                          <LowerEqual>
+                                                 <Simvar name="ELECTRICAL GENALT BUS AMPS:1" unit="amp"/>
+                                                 <Constant>0</Constant>
+                                          </LowerEqual>
+                                   </Or>
+                                   <Greater>
+                                          <Simvar name="TURB ENG N1:1" unit="percent"/>
+                                          <Constant>50</Constant>
+                                   </Greater>
+                            </And>
+                     </And>
 		</Condition>
 	</Annunciation>
 	<!--Indicates electrical power is being supplied to the engine ignition system-->		
@@ -433,7 +451,7 @@
 							</Greater>
 						</Transition>
 					</State>
-					<State id="Normal" value="900">
+					<State id="Normal" value="950">
 						<Transition to="Start">
 							<Lower>
 								<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -448,8 +466,27 @@
 			</Value>
 			<ColorZone>
 				<Color>green</Color>
-				<Begin>0</Begin>
-				<End>825</End>
+				<Begin>100</Begin>
+				<End>
+                                   <StateMachine>
+						<State id="Start" value="870">
+							<Transition to="Normal">
+								<Greater>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>52</Constant>
+								</Greater>
+							</Transition>
+						</State>
+						<State id="Normal" value="825">
+							<Transition to="Start">
+								<Lower>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>10</Constant>
+								</Lower>
+							</Transition>
+						</State>
+					</StateMachine>
+                            </End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
@@ -460,7 +497,7 @@
 				<Color>red</Color>
 				<Position>						
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -484,7 +521,7 @@
 				<Greater>
 					<Simvar name="TURB ENG1 ITT" unit="celsius"/>
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>

--- a/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/WTEngineDisplay.xml
+++ b/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/WTEngineDisplay.xml
@@ -37,7 +37,7 @@
 			</ColorZone>
 			<ColorZone>
 				<Color>red</Color>
-				<Begin>2396</Begin>
+				<Begin>2397</Begin>
 				<End>2600</End>
 			</ColorZone>
 			<GraduationLength>100</GraduationLength>
@@ -45,7 +45,7 @@
 			<RedBlink>
 				<Greater>
 					<Simvar name="ENG TORQUE:1" unit="Foot pounds"/>
-					<Constant>2400</Constant>
+					<Constant>2397</Constant>
 				</Greater>
 			</RedBlink>
 		</Gauge>
@@ -91,12 +91,12 @@
 			<ColorZone>
 				<Color>green</Color>
 				<Begin>100</Begin>
-				<End>740</End>
+				<End>825</End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
-				<Begin>765</Begin>
-				<End>805</End>
+				<Begin>826</Begin>
+				<End>849</End>
 			</ColorZone>
 			<ColorLine>
 				<Color>red</Color>
@@ -110,7 +110,7 @@
 								</Greater>
 							</Transition>
 						</State>
-						<State id="Normal" value="805">
+						<State id="Normal" value="850">
 							<Transition to="Start">
 								<Lower>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -134,7 +134,7 @@
 								</Greater>
 							</Transition>
 						</State>
-						<State id="Normal" value="805">
+						<State id="Normal" value="850">
 							<Transition to="Start">
 								<Lower>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -156,7 +156,7 @@
 				<CursorType>Triangle</CursorType>
 				<ValuePos>End</ValuePos>
 				<SizePercent>90</SizePercent>
-				<!--<TextIncrement>10</TextIncrement>-->
+				<TextIncrement>1</TextIncrement>
 			</Style>
 			<BeginText></BeginText>
 			<EndText></EndText>
@@ -170,13 +170,9 @@
 			</Value>
 			<ColorZone>
 				<Color>green</Color>
-				<Begin>51</Begin>
-				<End>101.6</End>
+				<Begin>55</Begin>
+				<End>103.6</End>
 			</ColorZone>
-			<ColorLine>
-				<Color>white</Color>
-				<Position>0</Position>
-			</ColorLine>
 			<ColorLine>
 				<Color>white</Color>
 				<Position>12</Position>
@@ -186,18 +182,14 @@
 				<Position>50</Position>
 			</ColorLine>
 			<ColorLine>
-				<Color>white</Color>
-				<Position>105</Position>
-			</ColorLine>
-			<ColorLine>
 				<Color>red</Color>
-				<Position>101.6</Position>
+				<Position>103.7</Position>
 			</ColorLine>
 			<GraduationLength>10</GraduationLength>
 			<RedBlink>
 				<Greater>
 					<Simvar name="TURB ENG N1:1" unit="percent"/>
-					<Constant>101.6</Constant>
+					<Constant>103.6</Constant>
 				</Greater>
 			</RedBlink>
 		</Gauge>
@@ -392,7 +384,7 @@
 			</ColorZone>
 			<ColorZone>
 				<Color>red</Color>
-				<Begin>2396</Begin>
+				<Begin>2397</Begin>
 				<End>2600</End>
 			</ColorZone>
 			<GraduationLength>100</GraduationLength>
@@ -400,7 +392,7 @@
 			<RedBlink>
 				<Greater>
 					<Simvar name="ENG TORQUE:1" unit="Foot pounds"/>
-					<Constant>2400</Constant>
+					<Constant>2397</Constant>
 				</Greater>
 			</RedBlink>
 		</Gauge>
@@ -446,12 +438,12 @@
 			<ColorZone>
 				<Color>green</Color>
 				<Begin>100</Begin>
-				<End>740</End>
+				<End>825</End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
-				<Begin>765</Begin>
-				<End>805</End>
+				<Begin>826</Begin>
+				<End>849</End>
 			</ColorZone>
 			<ColorLine>
 				<Color>red</Color>
@@ -465,7 +457,7 @@
 								</Greater>
 							</Transition>
 						</State>
-						<State id="Normal" value="805">
+						<State id="Normal" value="850">
 							<Transition to="Start">
 								<Lower>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -489,7 +481,7 @@
 								</Greater>
 							</Transition>
 						</State>
-						<State id="Normal" value="805">
+						<State id="Normal" value="850">
 							<Transition to="Start">
 								<Lower>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -511,7 +503,7 @@
 				<CursorType>Triangle</CursorType>
 				<ValuePos>End</ValuePos>
 				<SizePercent>90</SizePercent>
-				<!--<TextIncrement>10</TextIncrement>-->
+				<TextIncrement>1</TextIncrement>
 			</Style>
 			<BeginText></BeginText>
 			<EndText></EndText>
@@ -525,13 +517,9 @@
 			</Value>
 			<ColorZone>
 				<Color>green</Color>
-				<Begin>51</Begin>
-				<End>101.6</End>
+				<Begin>55</Begin>
+				<End>103.6</End>
 			</ColorZone>
-			<ColorLine>
-				<Color>white</Color>
-				<Position>0</Position>
-			</ColorLine>
 			<ColorLine>
 				<Color>white</Color>
 				<Position>12</Position>
@@ -541,18 +529,14 @@
 				<Position>50</Position>
 			</ColorLine>
 			<ColorLine>
-				<Color>white</Color>
-				<Position>105</Position>
-			</ColorLine>
-			<ColorLine>
 				<Color>red</Color>
-				<Position>101.6</Position>
+				<Position>103.7</Position>
 			</ColorLine>
 			<GraduationLength>10</GraduationLength>
 			<RedBlink>
 				<Greater>
 					<Simvar name="TURB ENG N1:1" unit="percent"/>
-					<Constant>101.6</Constant>
+					<Constant>103.6</Constant>
 				</Greater>
 			</RedBlink>
 		</Gauge>
@@ -606,7 +590,7 @@
 			<Title>OIL</Title>
 			<Unit>PSI</Unit>
 			<Minimum>0</Minimum>
-			<Maximum>120</Maximum>
+			<Maximum>130</Maximum>
 			<Value>
 				<Simvar name="GENERAL ENG OIL PRESSURE:1" unit="psi"/>
 			</Value>
@@ -618,11 +602,11 @@
 			<ColorZone>
 				<Color>yellow</Color>
 				<Begin>40</Begin>
-				<End>85</End>
+				<End>84</End>
 			</ColorZone>
 			<ColorLine>
 				<Color>red</Color>
-				<Position>40</Position>
+				<Position>39</Position>
 			</ColorLine>
 			<ColorLine>
 				<Color>red</Color>
@@ -659,13 +643,13 @@
 			</Value>
 			<ColorZone>
 				<Color>green</Color>
-				<Begin>10</Begin>
-				<End>100</End>
+				<Begin>32</Begin>
+				<End>99</End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
 				<Begin>-40</Begin>
-				<End>10</End>
+				<End>31</End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
@@ -686,11 +670,11 @@
 				<Or>
 					<Greater>
 						<Simvar name="GENERAL ENG OIL TEMPERATURE:1" unit="celsius"/>
-						<Constant>105</Constant>
+						<Constant>104</Constant>
 					</Greater>
 					<Lower>
 						<Simvar name="GENERAL ENG OIL TEMPERATURE:1" unit="celsius"/>
-						<Constant>-41</Constant>
+						<Constant>-40</Constant>
 					</Lower>
 				</Or>
 			</RedBlink>
@@ -708,7 +692,7 @@
 			<Title></Title>
 			<Unit>LBS</Unit>
 			<Minimum>0</Minimum>
-			<Maximum>1100</Maximum>
+			<Maximum>1145</Maximum>
 			<Style>
 				<Height>70</Height>
 			</Style>

--- a/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/WTEngineDisplay.xml
+++ b/C208B-mod/SimObjects/Airplanes/Asobo_208B_GRAND_CARAVAN_EX/panel/WTEngineDisplay.xml
@@ -75,7 +75,7 @@
 							</Greater>
 						</Transition>
 					</State>
-					<State id="Normal" value="900">
+					<State id="Normal" value="950">
 						<Transition to="Start">
 							<Lower>
 								<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -91,7 +91,26 @@
 			<ColorZone>
 				<Color>green</Color>
 				<Begin>100</Begin>
-				<End>825</End>
+				<End>
+                                   <StateMachine>
+						<State id="Start" value="870">
+							<Transition to="Normal">
+								<Greater>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>52</Constant>
+								</Greater>
+							</Transition>
+						</State>
+						<State id="Normal" value="825">
+							<Transition to="Start">
+								<Lower>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>10</Constant>
+								</Lower>
+							</Transition>
+						</State>
+					</StateMachine>
+                            </End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
@@ -102,7 +121,7 @@
 				<Color>red</Color>
 				<Position>						
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -126,7 +145,7 @@
 				<Greater>
 					<Simvar name="TURB ENG1 ITT" unit="celsius"/>
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -422,7 +441,7 @@
 							</Greater>
 						</Transition>
 					</State>
-					<State id="Normal" value="900">
+					<State id="Normal" value="950">
 						<Transition to="Start">
 							<Lower>
 								<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -438,7 +457,26 @@
 			<ColorZone>
 				<Color>green</Color>
 				<Begin>100</Begin>
-				<End>825</End>
+				<End>
+                                   <StateMachine>
+						<State id="Start" value="870">
+							<Transition to="Normal">
+								<Greater>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>52</Constant>
+								</Greater>
+							</Transition>
+						</State>
+						<State id="Normal" value="825">
+							<Transition to="Start">
+								<Lower>
+									<Simvar name="TURB ENG N1:1" unit="percent"/>
+									<Constant>10</Constant>
+								</Lower>
+							</Transition>
+						</State>
+					</StateMachine>
+                            </End>
 			</ColorZone>
 			<ColorZone>
 				<Color>yellow</Color>
@@ -449,7 +487,7 @@
 				<Color>red</Color>
 				<Position>						
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>
@@ -473,7 +511,7 @@
 				<Greater>
 					<Simvar name="TURB ENG1 ITT" unit="celsius"/>
 					<StateMachine>
-						<State id="Start" value="1090">
+						<State id="Start" value="871">
 							<Transition to="Normal">
 								<Greater>
 									<Simvar name="TURB ENG N1:1" unit="percent"/>


### PR DESCRIPTION
Changes:

Added new STBY PWR Annunciation (Only Shown if needed)
Engine Page between PFD and MFD are different, maybe cause I never published my reversionary mode version, which include that.
Also there where some wrong values in both files. Maybe I've looked into the wrong POH when I created this at the first time (or they changed something in the new POH).
Fixed: Battery Load (on PFD) is the wrong value (negativ when it should be positiv and vice versa)
Some small corrections on the gauges according to POH